### PR TITLE
QuestsLoadedEvent

### DIFF
--- a/src/main/java/gg/auroramc/quests/api/event/QuestsLoadedEvent.java
+++ b/src/main/java/gg/auroramc/quests/api/event/QuestsLoadedEvent.java
@@ -1,0 +1,26 @@
+package gg.auroramc.quests.api.event;
+
+import lombok.Getter;
+import org.bukkit.Bukkit;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+import org.jetbrains.annotations.NotNull;
+
+@Getter
+public class QuestsLoadedEvent extends Event {
+    private static final HandlerList HANDLERS = new HandlerList();
+
+    public static HandlerList getHandlerList() {
+        return HANDLERS;
+    }
+
+    @NotNull
+    @Override
+    public HandlerList getHandlers() {
+        return HANDLERS;
+    }
+
+    public QuestsLoadedEvent() {
+        super(!Bukkit.isPrimaryThread());
+    }
+}

--- a/src/main/java/gg/auroramc/quests/api/quest/QuestManager.java
+++ b/src/main/java/gg/auroramc/quests/api/quest/QuestManager.java
@@ -5,10 +5,12 @@ import gg.auroramc.aurora.api.AuroraAPI;
 import gg.auroramc.aurora.api.reward.*;
 import gg.auroramc.aurora.api.util.NamespacedId;
 import gg.auroramc.quests.AuroraQuests;
+import gg.auroramc.quests.api.event.QuestsLoadedEvent;
 import gg.auroramc.quests.api.quest.task.LevelledTaskEvaluator;
 import gg.auroramc.quests.hooks.HookManager;
 import gg.auroramc.quests.hooks.worldguard.WorldGuardHook;
 import lombok.Getter;
+import org.bukkit.Bukkit;
 import org.bukkit.GameMode;
 import org.bukkit.entity.Player;
 import org.quartz.SchedulerException;
@@ -51,6 +53,7 @@ public class QuestManager {
         for (var poolEntry : plugin.getConfigManager().getQuestPools().entrySet()) {
             pools.put(poolEntry.getKey(), new QuestPool(poolEntry.getValue(), rewardFactory));
         }
+        Bukkit.getPluginManager().callEvent(new QuestsLoadedEvent());
     }
 
     private Object getPlayerLock(Player player) {


### PR DESCRIPTION
Added an event that triggers when all quests are loaded. This is useful when you want to retrieve quests but don't know when they will be loaded.