### PR TITLE
Ensure tasks list is initialized before adding new task via `asyncInterval`

### DIFF
--- a/src/main/java/gg/auroramc/quests/api/objective/Objective.java
+++ b/src/main/java/gg/auroramc/quests/api/objective/Objective.java
@@ -95,6 +95,9 @@ public abstract class Objective extends EventBus {
     }
 
     protected void asyncInterval(Runnable runnable, int delay, int interval) {
+        if (tasks == null) {
+            tasks = new ArrayList<>();
+        }
         var task = Bukkit.getAsyncScheduler().runAtFixedRate(AuroraQuests.getInstance(), (t) -> {
             runnable.run();
         }, delay * 50L, interval * 50L, TimeUnit.MILLISECONDS);


### PR DESCRIPTION
Prevents NPE as in the following example:
```java
public static final class PlayOneMinuteObjective extends Objective {

    public PlayOneMinuteObjective(final Quest quest, final ObjectiveDefinition definition, final Profile.TaskDataWrapper data) {
        super(quest, definition, data);
    }

    @Override
    protected void activate() {
        asyncInterval(() -> progress(1, meta()), 1200, 1200);
    }

}
```

https://pastes.dev/OVcrzhLzPeDF

Tested these changes using the code above, and it appears it is now fixed.