### PR TITLE
Integrate MMOItems crafting stations into CRAFT quest objective progression

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -80,6 +80,8 @@ dependencies {
     compileOnly("su.nightexpress.excellentshop:Core:4.20.0") {
         exclude(group = "com.github.Xyness", module = "SimpleClaimSystem")
     }
+    compileOnly("io.lumine:MythicLib-dist:1.6.2-SNAPSHOT")
+    compileOnly("net.Indyuce:MMOItems-API:6.9.5-SNAPSHOT")
 
     implementation("co.aikar:acf-paper:0.5.1-SNAPSHOT")
     implementation("org.bstats:bstats-bukkit:3.0.2")

--- a/src/main/java/gg/auroramc/quests/hooks/Hooks.java
+++ b/src/main/java/gg/auroramc/quests/hooks/Hooks.java
@@ -9,6 +9,7 @@ import gg.auroramc.quests.hooks.economyshopgui.EconomyShopGuiHook;
 import gg.auroramc.quests.hooks.excellentshop.ExcellentShopHook;
 import gg.auroramc.quests.hooks.fancynpcs.FancyNPCsHook;
 import gg.auroramc.quests.hooks.luckperms.LuckPermsHook;
+import gg.auroramc.quests.hooks.mmoitems.MMOItemsHook;
 import gg.auroramc.quests.hooks.mmolib.MMOLibHook;
 import gg.auroramc.quests.hooks.mythicdungeons.DungeonsHook;
 import gg.auroramc.quests.hooks.mythicmobs.MythicHook;
@@ -44,7 +45,8 @@ public enum Hooks {
     ZNPCS(ZnpcsHook.class, "ServersNPC"),
     EXCELLENT_SHOP(ExcellentShopHook.class, "ExcellentShop"),
     NEXO(NexoHook.class, "Nexo"),
-    ZNPCSPlus(ZnpcPlusHook.class, "ZNPCsPlus");
+    ZNPCSPlus(ZnpcPlusHook.class, "ZNPCsPlus"),
+    MMOITEMS(MMOItemsHook.class, "MMOItems");
 
     private final Class<? extends Hook> clazz;
     private final Set<String> plugins;

--- a/src/main/java/gg/auroramc/quests/hooks/mmoitems/MMOItemsHook.java
+++ b/src/main/java/gg/auroramc/quests/hooks/mmoitems/MMOItemsHook.java
@@ -1,0 +1,51 @@
+package gg.auroramc.quests.hooks.mmoitems;
+
+import gg.auroramc.aurora.api.item.TypeId;
+import gg.auroramc.quests.AuroraQuests;
+import gg.auroramc.quests.api.event.objective.PlayerCraftedItemEvent;
+import gg.auroramc.quests.hooks.Hook;
+import net.Indyuce.mmoitems.MMOItems;
+import net.Indyuce.mmoitems.api.event.PlayerUseCraftingStationEvent;
+import org.bukkit.Bukkit;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.inventory.ItemStack;
+
+public class MMOItemsHook implements Hook, Listener {
+
+    @Override
+    public void hook(AuroraQuests plugin) {
+        AuroraQuests.logger().info("Hooked into MMOItems for CRAFT objectives.");
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onCraftItem(PlayerUseCraftingStationEvent event) {
+        PlayerUseCraftingStationEvent.StationAction action = event.getInteraction();
+        // Only when the player actually gets the item in hand
+        if (action != PlayerUseCraftingStationEvent.StationAction.CRAFTING_QUEUE
+                && action != PlayerUseCraftingStationEvent.StationAction.INSTANT_RECIPE) {
+            return;
+        }
+        // If no result, then skip
+        if (!event.hasResult()) {
+            return;
+        }
+        // Check if the result is an actual item
+        ItemStack stack = event.getResult();
+        if (stack == null || stack.getType().isAir()) {
+            return;
+        }
+        // MMOItems item ID
+        String mmoId = MMOItems.getID(stack);
+        if (mmoId == null) {
+            // That means this is not mmo item, we should ignore it
+            return;
+        }
+
+        // Call the craft item event
+        PlayerCraftedItemEvent craftEvent = new PlayerCraftedItemEvent(event.getPlayer(), TypeId.fromString("mmoitems:" + mmoId), stack.getAmount());
+        Bukkit.getPluginManager().callEvent(craftEvent);
+    }
+
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -27,6 +27,7 @@ softdepend:
   - "Nexo"
   - "ExcellentShop"
   - "ZNPCsPlus"
+  - "MMOItems"
 
 website: https://auroramc.gg
 


### PR DESCRIPTION
This pull request adds support for detecting MMOItems crafted through MMOItems Crafting Stations. CRAFT quest objectives can now progress when players craft MMOItems items using instant recipes or crafting queue claims.

To use this feature, simply use this:
```yaml
types:
  - "mmoitems:<mmoitems_id_case_sensitive>"
```