### PR TITLE
Objective: BLOCK_BRUSH

### DIFF
--- a/src/main/java/gg/auroramc/quests/AuroraQuests.java
+++ b/src/main/java/gg/auroramc/quests/AuroraQuests.java
@@ -195,6 +195,7 @@ public class AuroraQuests extends AuroraQuestsPlugin implements Listener {
     private void registerObjectives() {
         ObjectiveFactory.registerObjective(ObjectiveType.BLOCK_LOOT, BlockLootObjective.class);
         ObjectiveFactory.registerObjective(ObjectiveType.BLOCK_BREAK, BlockBreakObjective.class);
+        ObjectiveFactory.registerObjective(ObjectiveType.BLOCK_BRUSH, BlockBrushObjective.class);
         ObjectiveFactory.registerObjective(ObjectiveType.BLOCK_SHEAR, BlockShearObjective.class);
         ObjectiveFactory.registerObjective(ObjectiveType.BLOCK_SHEAR_LOOT, BlockShearLootObjective.class);
         ObjectiveFactory.registerObjective(ObjectiveType.BREED, BreedingObjective.class);

--- a/src/main/java/gg/auroramc/quests/api/objective/ObjectiveType.java
+++ b/src/main/java/gg/auroramc/quests/api/objective/ObjectiveType.java
@@ -48,4 +48,5 @@ public class ObjectiveType {
     public static final String BREAK_ITEM = "BREAK_ITEM";
     public static final String TRAVEL = "TRAVEL";
     public static final String PLAY_TIME = "PLAY_TIME";
+    public static final String BLOCK_BRUSH = "BLOCK_BRUSH";
 }

--- a/src/main/java/gg/auroramc/quests/objective/BlockBrushObjective.java
+++ b/src/main/java/gg/auroramc/quests/objective/BlockBrushObjective.java
@@ -1,0 +1,28 @@
+package gg.auroramc.quests.objective;
+
+import gg.auroramc.quests.api.objective.ObjectiveDefinition;
+import gg.auroramc.quests.api.objective.TypedObjective;
+import gg.auroramc.quests.api.profile.Profile;
+import gg.auroramc.quests.api.quest.Quest;
+import org.bukkit.block.BrushableBlock;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.block.BlockDropItemEvent;
+
+public final class BlockBrushObjective extends TypedObjective {
+
+    public BlockBrushObjective(final Quest quest, final ObjectiveDefinition definition, final Profile.TaskDataWrapper data) {
+        super(quest, definition, data);
+    }
+
+    @Override
+    protected void activate() {
+        onEvent(BlockDropItemEvent.class, this::onBlockBrush, EventPriority.MONITOR);
+    }
+
+    public void onBlockBrush(final BlockDropItemEvent e) {
+        // Brushable blocks drop nothing when broken and (by default) always generate an item when brushed. These two checks should be enough.
+        if (e.getBlockState() instanceof BrushableBlock && !e.getItems().isEmpty())
+            progress(1, meta(e.getBlock().getLocation(), e.getBlock().getType()));
+    }
+
+}


### PR DESCRIPTION
Triggered when a brushable block drops an item, which is a result of player brushing the block with a brush.
Tested briefly, appears to work as expected.