### PR TITLE
Objective: UNLOCK_VAULT

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -49,7 +49,7 @@ repositories {
 }
 
 dependencies {
-    compileOnly("io.papermc.paper:paper-api:1.21-R0.1-SNAPSHOT")
+    compileOnly("io.papermc.paper:paper-api:1.21.5-R0.1-SNAPSHOT")
     compileOnly("gg.auroramc:Aurora:2.5.1")
     compileOnly("gg.auroramc:AuroraLevels:1.6.2")
     compileOnly("net.luckperms:api:5.4")

--- a/src/main/java/gg/auroramc/quests/AuroraQuests.java
+++ b/src/main/java/gg/auroramc/quests/AuroraQuests.java
@@ -7,6 +7,7 @@ import gg.auroramc.aurora.api.command.CommandDispatcher;
 import gg.auroramc.aurora.api.events.user.AuroraUserLoadedEvent;
 import gg.auroramc.aurora.api.localization.LocalizationProvider;
 import gg.auroramc.aurora.api.user.AuroraUser;
+import gg.auroramc.aurora.api.util.Version;
 import gg.auroramc.quests.api.AuroraQuestsPlugin;
 import gg.auroramc.quests.api.data.QuestData;
 import gg.auroramc.quests.api.event.BukkitEventBus;
@@ -235,6 +236,10 @@ public class AuroraQuests extends AuroraQuestsPlugin implements Listener {
         ObjectiveFactory.registerObjective(ObjectiveType.BREAK_ITEM, BreakItemObjective.class);
         ObjectiveFactory.registerObjective(ObjectiveType.TRAVEL, TravelObjective.class);
         ObjectiveFactory.registerObjective(ObjectiveType.PLAY_TIME, PlayTimeObjective.class);
+        // VaultChangeStateEvent is available starting from Paper 1.21.5
+        if (Version.isAtLeastVersion(21, 5))
+            ObjectiveFactory.registerObjective(ObjectiveType.UNLOCK_VAULT, UnlockVaultObjective.class);
+
     }
 
     private void reloadUnlockTask() {

--- a/src/main/java/gg/auroramc/quests/api/objective/ObjectiveType.java
+++ b/src/main/java/gg/auroramc/quests/api/objective/ObjectiveType.java
@@ -48,4 +48,5 @@ public class ObjectiveType {
     public static final String BREAK_ITEM = "BREAK_ITEM";
     public static final String TRAVEL = "TRAVEL";
     public static final String PLAY_TIME = "PLAY_TIME";
+    public static final String UNLOCK_VAULT = "UNLOCK_VAULT";
 }

--- a/src/main/java/gg/auroramc/quests/objective/UnlockVaultObjective.java
+++ b/src/main/java/gg/auroramc/quests/objective/UnlockVaultObjective.java
@@ -1,0 +1,28 @@
+package gg.auroramc.quests.objective;
+
+import gg.auroramc.quests.api.objective.ObjectiveDefinition;
+import gg.auroramc.quests.api.objective.StringTypedObjective;
+import gg.auroramc.quests.api.profile.Profile;
+import gg.auroramc.quests.api.quest.Quest;
+import io.papermc.paper.event.block.VaultChangeStateEvent;
+import org.bukkit.block.data.type.Vault;
+import org.bukkit.event.EventPriority;
+
+public final class UnlockVaultObjective extends StringTypedObjective {
+
+    public UnlockVaultObjective(final Quest quest, final ObjectiveDefinition definition, final Profile.TaskDataWrapper data) {
+        super(quest, definition, data);
+    }
+
+    @Override
+    protected void activate() {
+        onEvent(VaultChangeStateEvent.class, this::onVaultStateChange, EventPriority.MONITOR);
+    }
+
+    public void onVaultStateChange(final VaultChangeStateEvent event) {
+        if (event.getBlock().getState() instanceof org.bukkit.block.Vault vault && event.getPlayer() != null && event.getNewState() == Vault.State.UNLOCKING) {
+            progress(1, meta(event.getBlock().getLocation(), vault.getLootTable().key().asString()));
+        }
+    }
+
+}


### PR DESCRIPTION
Triggers when player unlocks a vault. Different vault "types" can be distinguished by their loot-table.
Tested briefly and appears to work as expected.

Example:
```yml
# Any Vault
unlock_any_vault:
  task: UNLOCK_VAULT
  display: "{status}<gray>Unlock {required} vault(s). <dark_gray>(<gray>{current}<dark_gray>/<gray>{required}<dark_gray>)"
  args:
    amount: 1

# Ominous Vault
unlock_ominous_vault:
  task: UNLOCK_VAULT
  display: "{status}<gray>Unlock {required} ominous vault(s). <dark_gray>(<gray>{current}<dark_gray>/<gray>{required}<dark_gray>)"
  args:
    amount: 1
    types:
      - "minecraft:chests/trial_chambers/reward_ominous"
```

This objective is only registered on 1.21.5 and above because `VaultChangeStateEvent` does not exist until that version.